### PR TITLE
Fixed download links for a few Hugo shortcodes

### DIFF
--- a/content/purchases/buymeacoffee/index.md
+++ b/content/purchases/buymeacoffee/index.md
@@ -115,4 +115,4 @@ params:
 
 ## Installation
 
-{{< install-shortcode name="codepen" >}}
+{{< install-shortcode name="bmc-button" >}}

--- a/content/purchases/gumroad-button/index.md
+++ b/content/purchases/gumroad-button/index.md
@@ -58,4 +58,4 @@ params:
 
 ## Installation
 
-{{< install-shortcode name="codepen" >}}
+{{< install-shortcode name="gumroad-button" >}}


### PR DESCRIPTION
BuyMeACoffee and Gumroad shortcodes had incorrect links in "Install only current shortcode" section.
I have updated them to download of the correct files.

@isqua FYI 😊